### PR TITLE
Fix release workflow - use GitHub CLI instead of deprecated actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,26 +31,33 @@ jobs:
     - name: Package extension
       run: npm run package
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
+    - name: Check if release exists
+      id: check_release
+      run: |
+        if gh release view ${{ github.ref_name }} &>/dev/null; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
+
+    - name: Create Release
+      if: steps.check_release.outputs.exists == 'false'
+      run: |
+        gh release create ${{ github.ref_name }} \
+          --title "Release ${{ github.ref_name }}" \
+          --notes "Release ${{ github.ref_name }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
+      run: |
+        gh release upload ${{ github.ref_name }} \
+          ./manic-miners-dat-${{ github.ref_name }}.vsix \
+          --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./manic-miners-dat-${{ github.ref_name }}.vsix
-        asset_name: manic-miners-dat-${{ github.ref_name }}.vsix
-        asset_content_type: application/vsix
 
     - name: Publish to VS Code Marketplace
       env:

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "type-check": "tsc --noEmit",
-    "package": "vsce package",
+    "package": "vsce package --no-dependencies",
     "publish": "vsce publish"
   },
   "devDependencies": {


### PR DESCRIPTION
- Replace deprecated actions/create-release@v1 with gh CLI
- Handle case where release already exists
- Update to use GitHub CLI for asset uploads
- Add --no-dependencies flag to vsce package command
