### PR TITLE
Add undo/redo support for map edits with visual preview - Phase 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,45 @@
         "title": "Convert Objective Format",
         "category": "Manic Miners",
         "icon": "$(sync)"
+      },
+      {
+        "command": "manicMiners.undo",
+        "title": "Undo Map Edit",
+        "category": "Manic Miners",
+        "icon": "$(discard)"
+      },
+      {
+        "command": "manicMiners.redo",
+        "title": "Redo Map Edit",
+        "category": "Manic Miners",
+        "icon": "$(redo)"
+      },
+      {
+        "command": "manicMiners.showUndoRedoHistory",
+        "title": "Show Edit History",
+        "category": "Manic Miners",
+        "icon": "$(history)"
+      },
+      {
+        "command": "manicMiners.clearEditHistory",
+        "title": "Clear Edit History",
+        "category": "Manic Miners",
+        "icon": "$(clear-all)"
+      },
+      {
+        "command": "manicMiners.fillAreaEnhanced",
+        "title": "Fill Area (with Undo)",
+        "category": "Manic Miners"
+      },
+      {
+        "command": "manicMiners.replaceAllEnhanced",
+        "title": "Replace All Tiles (with Undo)",
+        "category": "Manic Miners"
+      },
+      {
+        "command": "manicMiners.replaceWithTileSetEnhanced",
+        "title": "Replace with Tile Set (with Undo)",
+        "category": "Manic Miners"
       }
     ],
     "hoverProviders": [
@@ -194,6 +233,26 @@
         }
       ]
     },
+    "keybindings": [
+      {
+        "command": "manicMiners.undo",
+        "key": "ctrl+alt+z",
+        "mac": "cmd+alt+z",
+        "when": "editorTextFocus && editorLangId == manicminers"
+      },
+      {
+        "command": "manicMiners.redo",
+        "key": "ctrl+alt+y",
+        "mac": "cmd+alt+y",
+        "when": "editorTextFocus && editorLangId == manicminers"
+      },
+      {
+        "command": "manicMiners.showUndoRedoHistory",
+        "key": "ctrl+alt+h",
+        "mac": "cmd+alt+h",
+        "when": "editorTextFocus && editorLangId == manicminers"
+      }
+    ],
     "snippets": [
       {
         "language": "manicminers",

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -60,14 +60,16 @@ describe('Extension', () => {
     it('should add all disposables to subscriptions', () => {
       activate(mockContext);
 
-      // Should have 30 subscriptions: hello world command, show map preview command, map preview provider,
+      // Should have 39 subscriptions: hello world command, show map preview command, map preview provider,
       // onDidChangeActiveTextEditor, onDidChangeTextDocument, completion provider, hover provider,
       // definition provider, reference provider, code actions provider (original), code actions provider (autoFix),
       // fill area command, replace all command, replace with tile set command, create tile set command,
       // insert template command, create template from selection command, manage templates command,
       // diagnostic collection, 3 validation listeners, 3 validation commands,
-      // objective builder view, 4 objective commands
-      expect(mockContext.subscriptions).toHaveLength(30);
+      // objective builder view, 4 objective commands,
+      // undo/redo provider (status bar + onDidChangeActiveTextEditor),
+      // enhanced quick actions (3 commands + 4 undo/redo commands + 1 clear history command)
+      expect(mockContext.subscriptions).toHaveLength(39);
     });
 
     it('should activate without errors', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,8 @@ import { registerValidationCommands } from './validation/validationCommands';
 import { ObjectiveBuilderProvider } from './objectiveBuilder/objectiveBuilderProvider';
 import { registerObjectiveCommands } from './objectiveBuilder/objectiveCommands';
 import { AutoFixProvider } from './validation/autoFixProvider';
+import { UndoRedoProvider } from './undoRedo/undoRedoProvider';
+import { registerEnhancedQuickActionsCommands } from './quickActions/quickActionsEnhanced';
 
 export function activate(context: vscode.ExtensionContext) {
   // Extension activated successfully
@@ -99,6 +101,9 @@ export function activate(context: vscode.ExtensionContext) {
   // Create tile sets manager
   const tileSetsManager = new CustomTileSetsManager(context);
 
+  // Create undo/redo provider
+  const undoRedoProvider = new UndoRedoProvider(context);
+
   // Register Quick Actions Provider
   const quickActionsProvider = vscode.languages.registerCodeActionsProvider(
     { scheme: 'file', language: 'manicminers' },
@@ -110,8 +115,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(quickActionsProvider);
 
-  // Register Quick Actions Commands
+  // Register Quick Actions Commands (keeping original for backward compatibility)
   registerQuickActionsCommands(context, tileSetsManager);
+
+  // Register Enhanced Quick Actions Commands with undo/redo support
+  registerEnhancedQuickActionsCommands(context, tileSetsManager, undoRedoProvider);
 
   // Register Map Template Commands
   registerMapTemplateCommands(context);

--- a/src/quickActions/quickActionsEnhanced.ts
+++ b/src/quickActions/quickActionsEnhanced.ts
@@ -1,0 +1,331 @@
+import * as vscode from 'vscode';
+import { DatFileParser } from '../parser/datFileParser';
+import { CustomTileSetsManager } from './customTileSets';
+import { UndoRedoProvider } from '../undoRedo/undoRedoProvider';
+import { EditChange } from '../undoRedo/editHistory';
+
+export function registerEnhancedQuickActionsCommands(
+  context: vscode.ExtensionContext,
+  tileSetsManager: CustomTileSetsManager,
+  undoRedoProvider: UndoRedoProvider
+): void {
+  // Enhanced fill area command with undo support
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'manicMiners.fillAreaEnhanced',
+      async (uri: vscode.Uri, range: vscode.Range, tileId: number) => {
+        const document = await vscode.workspace.openTextDocument(uri);
+        const edit = new vscode.WorkspaceEdit();
+        const changes: EditChange[] = [];
+
+        // Parse the tiles section
+        const parser = new DatFileParser(document.getText());
+        const tilesSection = parser.getSection('tiles');
+        if (!tilesSection) {
+          return;
+        }
+
+        // Get line offsets for tiles section
+        const lines = document.getText().split('\n');
+        const tilesStartLine = lines.findIndex(line => line.trim() === 'tiles{');
+        if (tilesStartLine === -1) {
+          return;
+        }
+
+        let tilesModified = 0;
+
+        // Process each line in the range
+        for (let line = range.start.line; line <= range.end.line; line++) {
+          const lineText = document.lineAt(line).text;
+          const tiles = lineText.split(',').map(t => t.trim());
+
+          // Determine which tiles to replace
+          let startCol = 0;
+          let endCol = tiles.length;
+
+          if (line === range.start.line || line === range.end.line) {
+            // For first and last lines, calculate column indices
+            let charCount = 0;
+            for (let i = 0; i < tiles.length; i++) {
+              if (line === range.start.line && charCount < range.start.character) {
+                startCol = i;
+              }
+              if (line === range.end.line && charCount <= range.end.character) {
+                endCol = i + 1;
+              }
+              charCount += tiles[i].length + 1; // +1 for comma
+            }
+          }
+
+          // Build the new line
+          const newTiles = [...tiles];
+          for (let i = startCol; i < endCol && i < tiles.length; i++) {
+            if (tiles[i] && tiles[i] !== '' && !isNaN(parseInt(tiles[i], 10))) {
+              newTiles[i] = String(tileId);
+              tilesModified++;
+            }
+          }
+
+          const newLine = newTiles.join(',');
+          if (newLine !== lineText) {
+            const lineRange = new vscode.Range(line, 0, line, lineText.length);
+            edit.replace(uri, lineRange, newLine);
+
+            // Record change for undo
+            changes.push({
+              range: lineRange,
+              oldText: lineText,
+              newText: newLine,
+            });
+          }
+        }
+
+        if (changes.length > 0) {
+          const success = await vscode.workspace.applyEdit(edit);
+          if (success) {
+            // Record in undo history
+            undoRedoProvider.recordEdit(
+              uri,
+              `Fill area with tile ${tileId} (${tilesModified} tiles)`,
+              changes
+            );
+
+            vscode.window.showInformationMessage(
+              `Filled ${tilesModified} tiles with tile ID ${tileId}`
+            );
+          }
+        }
+      }
+    )
+  );
+
+  // Enhanced replace all command with undo support
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'manicMiners.replaceAllEnhanced',
+      async (uri: vscode.Uri, fromTileId: number) => {
+        const toTileId = await vscode.window.showInputBox({
+          prompt: `Replace all instances of tile ${fromTileId} with:`,
+          placeHolder: 'Enter tile ID (1-299)',
+          validateInput: value => {
+            const id = parseInt(value, 10);
+            if (isNaN(id) || id < 1 || id > 299) {
+              return 'Please enter a valid tile ID (1-299)';
+            }
+            return null;
+          },
+        });
+
+        if (!toTileId) {
+          return;
+        }
+
+        const newTileId = parseInt(toTileId, 10);
+        const document = await vscode.workspace.openTextDocument(uri);
+        const edit = new vscode.WorkspaceEdit();
+        const changes: EditChange[] = [];
+
+        // Parse the tiles section
+        const parser = new DatFileParser(document.getText());
+        const tilesSection = parser.getSection('tiles');
+        if (!tilesSection) {
+          return;
+        }
+
+        // Get line offsets for tiles section
+        const lines = document.getText().split('\n');
+        const tilesStartLine = lines.findIndex(line => line.trim() === 'tiles{');
+        const tilesEndLine = lines.findIndex(
+          (line, index) => index > tilesStartLine && line.trim() === '}'
+        );
+
+        if (tilesStartLine === -1 || tilesEndLine === -1) {
+          return;
+        }
+
+        let replacementCount = 0;
+
+        // Process each line in the tiles section
+        for (let line = tilesStartLine + 1; line < tilesEndLine; line++) {
+          const lineText = document.lineAt(line).text;
+          const tiles = lineText.split(',');
+          let modified = false;
+
+          const newTiles = tiles.map(tile => {
+            const trimmed = tile.trim();
+            if (trimmed === String(fromTileId)) {
+              modified = true;
+              replacementCount++;
+              return tile.replace(trimmed, String(newTileId));
+            }
+            return tile;
+          });
+
+          if (modified) {
+            const newLine = newTiles.join(',');
+            const lineRange = new vscode.Range(line, 0, line, lineText.length);
+            edit.replace(uri, lineRange, newLine);
+
+            // Record change for undo
+            changes.push({
+              range: lineRange,
+              oldText: lineText,
+              newText: newLine,
+            });
+          }
+        }
+
+        if (changes.length > 0) {
+          const success = await vscode.workspace.applyEdit(edit);
+          if (success) {
+            // Record in undo history
+            undoRedoProvider.recordEdit(
+              uri,
+              `Replace all tile ${fromTileId} with ${newTileId} (${replacementCount} instances)`,
+              changes
+            );
+
+            vscode.window.showInformationMessage(
+              `Replaced ${replacementCount} instances of tile ${fromTileId} with tile ${newTileId}`
+            );
+          }
+        } else {
+          vscode.window.showInformationMessage(`No instances of tile ${fromTileId} found`);
+        }
+      }
+    )
+  );
+
+  // Enhanced replace with tile set command
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'manicMiners.replaceWithTileSetEnhanced',
+      async (uri: vscode.Uri, range: vscode.Range) => {
+        const tileSet = await tileSetsManager.showTileSetPicker();
+        if (!tileSet || tileSet.tiles.length === 0) {
+          return;
+        }
+
+        const document = await vscode.workspace.openTextDocument(uri);
+        const selectedText = document.getText(range);
+        const tileMatch = selectedText.match(/\b(\d+)\b/);
+
+        if (!tileMatch) {
+          vscode.window.showErrorMessage('No tile ID found at cursor position');
+          return;
+        }
+
+        const currentTileId = parseInt(tileMatch[1], 10);
+
+        // Show picker for which tile from the set to use
+        const items = tileSet.tiles.map(id => ({
+          label: `Tile ${id}`,
+          description: getTileName(id),
+          id,
+        }));
+
+        const selected = await vscode.window.showQuickPick(items, {
+          placeHolder: `Replace tile ${currentTileId} with:`,
+        });
+
+        if (!selected) {
+          return;
+        }
+
+        const edit = new vscode.WorkspaceEdit();
+        const replaceRange = new vscode.Range(
+          range.start.line,
+          range.start.character + tileMatch.index!,
+          range.start.line,
+          range.start.character + tileMatch.index! + tileMatch[0].length
+        );
+
+        const oldText = document.getText(replaceRange);
+        const newText = String(selected.id);
+
+        edit.replace(uri, replaceRange, newText);
+
+        const success = await vscode.workspace.applyEdit(edit);
+        if (success) {
+          // Record in undo history
+          undoRedoProvider.recordEdit(
+            uri,
+            `Replace tile ${currentTileId} with ${selected.id} from ${tileSet.name}`,
+            [
+              {
+                range: replaceRange,
+                oldText,
+                newText,
+              },
+            ]
+          );
+        }
+      }
+    )
+  );
+
+  // Undo command
+  context.subscriptions.push(
+    vscode.commands.registerCommand('manicMiners.undo', async () => {
+      await undoRedoProvider.undoWithPreview();
+    })
+  );
+
+  // Redo command
+  context.subscriptions.push(
+    vscode.commands.registerCommand('manicMiners.redo', async () => {
+      await undoRedoProvider.redoWithPreview();
+    })
+  );
+
+  // Show history command
+  context.subscriptions.push(
+    vscode.commands.registerCommand('manicMiners.showUndoRedoHistory', async () => {
+      await undoRedoProvider.showHistoryPanel();
+    })
+  );
+
+  // Clear history command
+  context.subscriptions.push(
+    vscode.commands.registerCommand('manicMiners.clearEditHistory', async () => {
+      const result = await vscode.window.showWarningMessage(
+        'Clear all edit history for the current file?',
+        { modal: true },
+        'Clear',
+        'Cancel'
+      );
+
+      if (result === 'Clear') {
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+          undoRedoProvider.clearHistory(editor.document.uri);
+          vscode.window.showInformationMessage('Edit history cleared');
+        }
+      }
+    })
+  );
+}
+
+function getTileName(tileId: number): string {
+  const tileNames: { [key: number]: string } = {
+    1: 'Ground',
+    6: 'Lava',
+    11: 'Water',
+    26: 'Dirt',
+    30: 'Loose Rock',
+    34: 'Hard Rock',
+    38: 'Solid Rock',
+    40: 'Solid Rock',
+    42: 'Crystal Seam',
+    46: 'Ore Seam',
+    50: 'Recharge Seam',
+  };
+
+  if (tileId >= 51 && tileId <= 100) {
+    const baseId = tileId - 50;
+    const baseName = tileNames[baseId] || `Tile ${baseId}`;
+    return `Reinforced ${baseName}`;
+  }
+
+  return tileNames[tileId] || `Tile ${tileId}`;
+}

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -109,7 +109,17 @@ export const window = {
     webview: {
       html: '',
       asWebviewUri: jest.fn(uri => uri),
+      onDidReceiveMessage: jest.fn(),
     },
+    dispose: jest.fn(),
+    onDidDispose: jest.fn(),
+  })),
+  createStatusBarItem: jest.fn(() => ({
+    text: '',
+    tooltip: '',
+    command: '',
+    show: jest.fn(),
+    hide: jest.fn(),
     dispose: jest.fn(),
   })),
 };
@@ -206,6 +216,11 @@ export enum ViewColumn {
   Seven = 7,
   Eight = 8,
   Nine = 9,
+}
+
+export enum StatusBarAlignment {
+  Left = 1,
+  Right = 2,
 }
 
 // Mock TextDocument

--- a/src/undoRedo/editHistory.test.ts
+++ b/src/undoRedo/editHistory.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { EditHistory, MapEdit } from './editHistory';
+import * as vscode from 'vscode';
+
+describe('EditHistory', () => {
+  let history: EditHistory;
+  let mockUri: vscode.Uri;
+
+  beforeEach(() => {
+    history = new EditHistory();
+    mockUri = vscode.Uri.file('/test/file.dat');
+  });
+
+  const createMockEdit = (id: string, description: string): MapEdit => ({
+    id,
+    timestamp: new Date(),
+    description,
+    documentUri: mockUri,
+    changes: [
+      {
+        range: new vscode.Range(0, 0, 0, 10),
+        oldText: '1,1,1',
+        newText: '2,2,2',
+      },
+    ],
+  });
+
+  describe('addEdit', () => {
+    it('should add edit to history', () => {
+      const edit = createMockEdit('1', 'Test edit');
+      history.addEdit(edit);
+
+      expect(history.getHistorySize()).toBe(1);
+      expect(history.getCurrentEdit()).toEqual(edit);
+    });
+
+    it('should maintain max history size', () => {
+      const smallHistory = new EditHistory(3);
+
+      for (let i = 0; i < 5; i++) {
+        smallHistory.addEdit(createMockEdit(`${i}`, `Edit ${i}`));
+      }
+
+      expect(smallHistory.getHistorySize()).toBe(3);
+      expect(smallHistory.getCurrentEdit()?.description).toBe('Edit 4');
+    });
+
+    it('should clear redo history when adding new edit', () => {
+      history.addEdit(createMockEdit('1', 'Edit 1'));
+      history.addEdit(createMockEdit('2', 'Edit 2'));
+      history.undo();
+
+      expect(history.canRedo()).toBe(true);
+
+      history.addEdit(createMockEdit('3', 'Edit 3'));
+
+      expect(history.canRedo()).toBe(false);
+      expect(history.getHistorySize()).toBe(2);
+    });
+  });
+
+  describe('undo', () => {
+    it('should undo last edit', () => {
+      const edit1 = createMockEdit('1', 'Edit 1');
+      const edit2 = createMockEdit('2', 'Edit 2');
+
+      history.addEdit(edit1);
+      history.addEdit(edit2);
+
+      const undoneEdit = history.undo();
+
+      expect(undoneEdit).toEqual(edit2);
+      expect(history.getCurrentEdit()).toEqual(edit1);
+    });
+
+    it('should return undefined when nothing to undo', () => {
+      expect(history.undo()).toBeUndefined();
+    });
+
+    it('should allow multiple undos', () => {
+      history.addEdit(createMockEdit('1', 'Edit 1'));
+      history.addEdit(createMockEdit('2', 'Edit 2'));
+      history.addEdit(createMockEdit('3', 'Edit 3'));
+
+      history.undo();
+      history.undo();
+
+      expect(history.getCurrentEdit()?.description).toBe('Edit 1');
+    });
+  });
+
+  describe('redo', () => {
+    it('should redo undone edit', () => {
+      const edit1 = createMockEdit('1', 'Edit 1');
+      const edit2 = createMockEdit('2', 'Edit 2');
+
+      history.addEdit(edit1);
+      history.addEdit(edit2);
+      history.undo();
+
+      const redoneEdit = history.redo();
+
+      expect(redoneEdit).toEqual(edit2);
+      expect(history.getCurrentEdit()).toEqual(edit2);
+    });
+
+    it('should return undefined when nothing to redo', () => {
+      history.addEdit(createMockEdit('1', 'Edit 1'));
+      expect(history.redo()).toBeUndefined();
+    });
+
+    it('should allow multiple redos', () => {
+      history.addEdit(createMockEdit('1', 'Edit 1'));
+      history.addEdit(createMockEdit('2', 'Edit 2'));
+      history.addEdit(createMockEdit('3', 'Edit 3'));
+
+      history.undo();
+      history.undo();
+      history.redo();
+      history.redo();
+
+      expect(history.getCurrentEdit()?.description).toBe('Edit 3');
+    });
+  });
+
+  describe('canUndo/canRedo', () => {
+    it('should correctly report undo/redo availability', () => {
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
+
+      history.addEdit(createMockEdit('1', 'Edit 1'));
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
+
+      history.undo();
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(true);
+
+      history.redo();
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear all history', () => {
+      history.addEdit(createMockEdit('1', 'Edit 1'));
+      history.addEdit(createMockEdit('2', 'Edit 2'));
+
+      history.clear();
+
+      expect(history.getHistorySize()).toBe(0);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
+    });
+  });
+
+  describe('getHistory', () => {
+    it('should return copy of history', () => {
+      const edit1 = createMockEdit('1', 'Edit 1');
+      const edit2 = createMockEdit('2', 'Edit 2');
+
+      history.addEdit(edit1);
+      history.addEdit(edit2);
+
+      const historyArray = history.getHistory();
+
+      expect(historyArray).toHaveLength(2);
+      expect(historyArray[0]).toEqual(edit1);
+      expect(historyArray[1]).toEqual(edit2);
+
+      // Verify it's a copy
+      historyArray.pop();
+      expect(history.getHistorySize()).toBe(2);
+    });
+  });
+});

--- a/src/undoRedo/editHistory.ts
+++ b/src/undoRedo/editHistory.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+
+export interface MapEdit {
+  id: string;
+  timestamp: Date;
+  description: string;
+  documentUri: vscode.Uri;
+  changes: EditChange[];
+}
+
+export interface EditChange {
+  range: vscode.Range;
+  oldText: string;
+  newText: string;
+}
+
+export class EditHistory {
+  private history: MapEdit[] = [];
+  private currentIndex: number = -1;
+  private maxHistorySize: number = 50;
+
+  constructor(maxHistorySize: number = 50) {
+    this.maxHistorySize = maxHistorySize;
+  }
+
+  public addEdit(edit: MapEdit): void {
+    // Remove any edits after the current index (redo history)
+    if (this.currentIndex < this.history.length - 1) {
+      this.history = this.history.slice(0, this.currentIndex + 1);
+    }
+
+    // Add the new edit
+    this.history.push(edit);
+    this.currentIndex++;
+
+    // Maintain max history size
+    if (this.history.length > this.maxHistorySize) {
+      this.history.shift();
+      this.currentIndex--;
+    }
+  }
+
+  public canUndo(): boolean {
+    return this.currentIndex >= 0;
+  }
+
+  public canRedo(): boolean {
+    return this.currentIndex < this.history.length - 1;
+  }
+
+  public getCurrentEdit(): MapEdit | undefined {
+    if (this.currentIndex >= 0 && this.currentIndex < this.history.length) {
+      return this.history[this.currentIndex];
+    }
+    return undefined;
+  }
+
+  public getUndoEdit(): MapEdit | undefined {
+    if (this.canUndo()) {
+      return this.history[this.currentIndex];
+    }
+    return undefined;
+  }
+
+  public getRedoEdit(): MapEdit | undefined {
+    if (this.canRedo()) {
+      return this.history[this.currentIndex + 1];
+    }
+    return undefined;
+  }
+
+  public undo(): MapEdit | undefined {
+    if (this.canUndo()) {
+      const edit = this.history[this.currentIndex];
+      this.currentIndex--;
+      return edit;
+    }
+    return undefined;
+  }
+
+  public redo(): MapEdit | undefined {
+    if (this.canRedo()) {
+      this.currentIndex++;
+      return this.history[this.currentIndex];
+    }
+    return undefined;
+  }
+
+  public clear(): void {
+    this.history = [];
+    this.currentIndex = -1;
+  }
+
+  public getHistory(): MapEdit[] {
+    return [...this.history];
+  }
+
+  public getHistorySize(): number {
+    return this.history.length;
+  }
+
+  public getCurrentIndex(): number {
+    return this.currentIndex;
+  }
+}

--- a/src/undoRedo/undoRedoPreview.ts
+++ b/src/undoRedo/undoRedoPreview.ts
@@ -1,0 +1,341 @@
+import * as vscode from 'vscode';
+import { MapEdit } from './editHistory';
+import { DatFileParser } from '../parser/datFileParser';
+import { getTileInfo } from '../data/tileDefinitions';
+import { getEnhancedTileInfo } from '../data/enhancedTileDefinitions';
+import { getExtendedTileInfo } from '../data/extendedTileDefinitions';
+
+export class UndoRedoPreviewProvider {
+  private static readonly viewType = 'manicMiners.undoRedoPreview';
+
+  public static async showPreview(
+    context: vscode.ExtensionContext,
+    edit: MapEdit,
+    action: 'undo' | 'redo'
+  ): Promise<boolean> {
+    const document = await vscode.workspace.openTextDocument(edit.documentUri);
+    const parser = new DatFileParser(document.getText());
+    const info = parser.getSection('info');
+
+    if (!info) {
+      return false;
+    }
+
+    // Extract map dimensions
+    const rowMatch = info.content?.match(/rowcount:\s*(\d+)/);
+    const colMatch = info.content?.match(/colcount:\s*(\d+)/);
+
+    if (!rowMatch || !colMatch) {
+      return false;
+    }
+
+    const rows = parseInt(rowMatch[1]);
+    const cols = parseInt(colMatch[1]);
+
+    // Create preview panel
+    const panel = vscode.window.createWebviewPanel(
+      this.viewType,
+      `${action === 'undo' ? 'Undo' : 'Redo'} Preview: ${edit.description}`,
+      vscode.ViewColumn.Two,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: false,
+      }
+    );
+
+    // Generate preview HTML
+    const html = this.generatePreviewHtml(
+      context,
+      panel.webview,
+      edit,
+      action,
+      rows,
+      cols,
+      document
+    );
+
+    panel.webview.html = html;
+
+    // Wait for user response
+    return new Promise<boolean>(resolve => {
+      let resolved = false;
+
+      // Handle messages from webview
+      panel.webview.onDidReceiveMessage(
+        message => {
+          if (message.command === 'proceed') {
+            resolved = true;
+            panel.dispose();
+            resolve(true);
+          } else if (message.command === 'cancel') {
+            resolved = true;
+            panel.dispose();
+            resolve(false);
+          }
+        },
+        undefined,
+        []
+      );
+
+      // Handle panel disposal
+      panel.onDidDispose(() => {
+        if (!resolved) {
+          resolve(false);
+        }
+      });
+    });
+  }
+
+  private static generatePreviewHtml(
+    _context: vscode.ExtensionContext,
+    _webview: vscode.Webview,
+    edit: MapEdit,
+    action: 'undo' | 'redo',
+    rows: number,
+    cols: number,
+    document: vscode.TextDocument
+  ): string {
+    // Calculate affected tiles
+    const affectedTiles = new Map<string, { before: number; after: number }>();
+
+    // Get current tiles
+    const lines = document.getText().split('\n');
+    const tilesStartLine = lines.findIndex(line => line.trim() === 'tiles{');
+
+    for (const change of edit.changes) {
+      const lineNum = change.range.start.line;
+      const relativeRow = lineNum - tilesStartLine - 1;
+
+      if (relativeRow >= 0 && relativeRow < rows) {
+        const oldTiles = change.oldText.split(',').map(t => parseInt(t.trim()));
+        const newTiles = change.newText.split(',').map(t => parseInt(t.trim()));
+
+        for (let col = 0; col < Math.min(oldTiles.length, newTiles.length, cols); col++) {
+          if (oldTiles[col] !== newTiles[col]) {
+            const key = `${relativeRow},${col}`;
+            affectedTiles.set(key, {
+              before: action === 'undo' ? newTiles[col] : oldTiles[col],
+              after: action === 'undo' ? oldTiles[col] : newTiles[col],
+            });
+          }
+        }
+      }
+    }
+
+    // Generate tile grid visualization
+    const tileSize = Math.min(600 / cols, 600 / rows, 20);
+    const gridHtml = this.generateTileGrid(rows, cols, affectedTiles, tileSize);
+
+    // Generate changes summary
+    const changesHtml = this.generateChangesSummary(affectedTiles);
+
+    return `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <style>
+          body {
+            font-family: var(--vscode-font-family);
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background);
+            padding: 20px;
+            margin: 0;
+          }
+          h2 {
+            margin-top: 0;
+          }
+          .preview-container {
+            display: flex;
+            gap: 20px;
+            margin-bottom: 20px;
+          }
+          .tile-grid {
+            border: 1px solid var(--vscode-panel-border);
+            display: inline-block;
+          }
+          .tile {
+            display: inline-block;
+            border: 1px solid var(--vscode-panel-border);
+            text-align: center;
+            font-size: 10px;
+            cursor: pointer;
+            position: relative;
+          }
+          .tile.affected {
+            border: 2px solid var(--vscode-editorWarning-foreground);
+          }
+          .tile.affected::after {
+            content: attr(data-change);
+            position: absolute;
+            top: -20px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: var(--vscode-editor-background);
+            padding: 2px 4px;
+            border: 1px solid var(--vscode-panel-border);
+            font-size: 9px;
+            white-space: nowrap;
+            display: none;
+          }
+          .tile.affected:hover::after {
+            display: block;
+          }
+          .changes-summary {
+            flex: 1;
+            max-height: 600px;
+            overflow-y: auto;
+          }
+          .change-item {
+            padding: 5px;
+            margin: 5px 0;
+            border-radius: 3px;
+            background: var(--vscode-editor-inactiveSelectionBackground);
+          }
+          .buttons {
+            margin-top: 20px;
+            text-align: center;
+          }
+          button {
+            padding: 8px 16px;
+            margin: 0 5px;
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 14px;
+          }
+          .proceed {
+            background: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
+          }
+          .proceed:hover {
+            background: var(--vscode-button-hoverBackground);
+          }
+          .cancel {
+            background: var(--vscode-button-secondaryBackground);
+            color: var(--vscode-button-secondaryForeground);
+          }
+          .cancel:hover {
+            background: var(--vscode-button-secondaryHoverBackground);
+          }
+          .legend {
+            margin-top: 10px;
+            font-size: 12px;
+          }
+          .legend-item {
+            display: inline-block;
+            margin-right: 15px;
+          }
+          .legend-color {
+            display: inline-block;
+            width: 20px;
+            height: 10px;
+            margin-right: 5px;
+            vertical-align: middle;
+          }
+        </style>
+      </head>
+      <body>
+        <h2>${action === 'undo' ? 'Undo' : 'Redo'}: ${edit.description}</h2>
+        
+        <div class="preview-container">
+          <div>
+            <h3>Affected Tiles</h3>
+            ${gridHtml}
+            <div class="legend">
+              <div class="legend-item">
+                <span class="legend-color" style="background: var(--vscode-editorWarning-foreground);"></span>
+                <span>Tiles to be changed</span>
+              </div>
+            </div>
+          </div>
+          
+          <div class="changes-summary">
+            <h3>Changes Summary (${affectedTiles.size} tiles)</h3>
+            ${changesHtml}
+          </div>
+        </div>
+        
+        <div class="buttons">
+          <button class="proceed" onclick="proceed()">
+            ${action === 'undo' ? 'Undo' : 'Redo'} Changes
+          </button>
+          <button class="cancel" onclick="cancel()">Cancel</button>
+        </div>
+        
+        <script>
+          const vscode = acquireVsCodeApi();
+          
+          function proceed() {
+            vscode.postMessage({ command: 'proceed' });
+          }
+          
+          function cancel() {
+            vscode.postMessage({ command: 'cancel' });
+          }
+        </script>
+      </body>
+      </html>
+    `;
+  }
+
+  private static generateTileGrid(
+    rows: number,
+    cols: number,
+    affectedTiles: Map<string, { before: number; after: number }>,
+    tileSize: number
+  ): string {
+    let html = '<div class="tile-grid">';
+
+    for (let row = 0; row < rows; row++) {
+      html += '<div>';
+      for (let col = 0; col < cols; col++) {
+        const key = `${row},${col}`;
+        const change = affectedTiles.get(key);
+        const isAffected = change !== undefined;
+
+        html += `<div class="tile ${isAffected ? 'affected' : ''}" 
+          style="width: ${tileSize}px; height: ${tileSize}px; line-height: ${tileSize}px;"
+          ${isAffected ? `data-change="${change.before} → ${change.after}"` : ''}>
+          ${isAffected ? '•' : ''}
+        </div>`;
+      }
+      html += '</div>';
+    }
+
+    html += '</div>';
+    return html;
+  }
+
+  private static generateChangesSummary(
+    affectedTiles: Map<string, { before: number; after: number }>
+  ): string {
+    // Group changes by tile type transition
+    const transitions = new Map<string, number>();
+
+    for (const change of affectedTiles.values()) {
+      const key = `${change.before} → ${change.after}`;
+      transitions.set(key, (transitions.get(key) || 0) + 1);
+    }
+
+    let html = '';
+    for (const [transition, count] of transitions) {
+      const [beforeId, afterId] = transition.split(' → ').map(id => parseInt(id));
+      const beforeInfo =
+        getTileInfo(beforeId) || getEnhancedTileInfo(beforeId) || getExtendedTileInfo(beforeId);
+      const afterInfo =
+        getTileInfo(afterId) || getEnhancedTileInfo(afterId) || getExtendedTileInfo(afterId);
+
+      const beforeName = beforeInfo?.name || `Tile ${beforeId}`;
+      const afterName = afterInfo?.name || `Tile ${afterId}`;
+
+      html += `
+        <div class="change-item">
+          <strong>${beforeName} (${beforeId})</strong> → <strong>${afterName} (${afterId})</strong>
+          <span style="float: right;">${count} tile${count > 1 ? 's' : ''}</span>
+        </div>
+      `;
+    }
+
+    return html;
+  }
+}

--- a/src/undoRedo/undoRedoProvider.ts
+++ b/src/undoRedo/undoRedoProvider.ts
@@ -1,0 +1,266 @@
+import * as vscode from 'vscode';
+import { EditHistory, MapEdit, EditChange } from './editHistory';
+import { UndoRedoPreviewProvider } from './undoRedoPreview';
+
+export class UndoRedoProvider {
+  private editHistories: Map<string, EditHistory> = new Map();
+  private statusBarItem: vscode.StatusBarItem;
+  private previewPanel: vscode.WebviewPanel | undefined;
+  private context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+    // Create status bar item
+    this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+    this.statusBarItem.command = 'manicMiners.showUndoRedoHistory';
+    context.subscriptions.push(this.statusBarItem);
+
+    // Update status bar when active editor changes
+    context.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor(() => {
+        this.updateStatusBar();
+      })
+    );
+  }
+
+  public getOrCreateHistory(uri: vscode.Uri): EditHistory {
+    const key = uri.toString();
+    let history = this.editHistories.get(key);
+    if (!history) {
+      history = new EditHistory();
+      this.editHistories.set(key, history);
+    }
+    return history;
+  }
+
+  public recordEdit(uri: vscode.Uri, description: string, changes: EditChange[]): void {
+    const history = this.getOrCreateHistory(uri);
+    const edit: MapEdit = {
+      id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      timestamp: new Date(),
+      description,
+      documentUri: uri,
+      changes,
+    };
+    history.addEdit(edit);
+    this.updateStatusBar();
+  }
+
+  public async undoWithPreview(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'manicminers') {
+      vscode.window.showErrorMessage('No active Manic Miners file');
+      return;
+    }
+
+    const history = this.getOrCreateHistory(editor.document.uri);
+    const edit = history.getUndoEdit();
+    if (!edit) {
+      vscode.window.showInformationMessage('Nothing to undo');
+      return;
+    }
+
+    // Show preview
+    const proceed = await this.showPreview(edit, 'undo');
+    if (!proceed) {
+      return;
+    }
+
+    // Apply undo
+    const undoEdit = new vscode.WorkspaceEdit();
+    for (const change of edit.changes) {
+      undoEdit.replace(editor.document.uri, change.range, change.oldText);
+    }
+
+    const success = await vscode.workspace.applyEdit(undoEdit);
+    if (success) {
+      history.undo();
+      this.updateStatusBar();
+      vscode.window.showInformationMessage(`Undid: ${edit.description}`);
+    }
+  }
+
+  public async redoWithPreview(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'manicminers') {
+      vscode.window.showErrorMessage('No active Manic Miners file');
+      return;
+    }
+
+    const history = this.getOrCreateHistory(editor.document.uri);
+    const edit = history.getRedoEdit();
+    if (!edit) {
+      vscode.window.showInformationMessage('Nothing to redo');
+      return;
+    }
+
+    // Show preview
+    const proceed = await this.showPreview(edit, 'redo');
+    if (!proceed) {
+      return;
+    }
+
+    // Apply redo
+    const redoEdit = new vscode.WorkspaceEdit();
+    for (const change of edit.changes) {
+      redoEdit.replace(editor.document.uri, change.range, change.newText);
+    }
+
+    const success = await vscode.workspace.applyEdit(redoEdit);
+    if (success) {
+      history.redo();
+      this.updateStatusBar();
+      vscode.window.showInformationMessage(`Redid: ${edit.description}`);
+    }
+  }
+
+  private async showPreview(edit: MapEdit, action: 'undo' | 'redo'): Promise<boolean> {
+    // Use enhanced preview with visual grid
+    return await UndoRedoPreviewProvider.showPreview(this.context, edit, action);
+  }
+
+  private updateStatusBar(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'manicminers') {
+      this.statusBarItem.hide();
+      return;
+    }
+
+    const history = this.getOrCreateHistory(editor.document.uri);
+    const canUndo = history.canUndo();
+    const canRedo = history.canRedo();
+    const historySize = history.getHistorySize();
+    const currentIndex = history.getCurrentIndex();
+
+    if (historySize > 0) {
+      this.statusBarItem.text = `$(history) ${currentIndex + 1}/${historySize}`;
+      this.statusBarItem.tooltip = `Undo/Redo History\n${canUndo ? '• Can undo' : '• Nothing to undo'}\n${canRedo ? '• Can redo' : '• Nothing to redo'}\nClick to view history`;
+      this.statusBarItem.show();
+    } else {
+      this.statusBarItem.text = '$(history) 0/0';
+      this.statusBarItem.tooltip = 'No edit history';
+      this.statusBarItem.show();
+    }
+  }
+
+  public async showHistoryPanel(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'manicminers') {
+      vscode.window.showErrorMessage('No active Manic Miners file');
+      return;
+    }
+
+    const history = this.getOrCreateHistory(editor.document.uri);
+    const edits = history.getHistory();
+    const currentIndex = history.getCurrentIndex();
+
+    if (edits.length === 0) {
+      vscode.window.showInformationMessage('No edit history');
+      return;
+    }
+
+    // Create webview panel
+    if (!this.previewPanel) {
+      this.previewPanel = vscode.window.createWebviewPanel(
+        'undoRedoHistory',
+        'Edit History',
+        vscode.ViewColumn.Two,
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+        }
+      );
+
+      this.previewPanel.onDidDispose(() => {
+        this.previewPanel = undefined;
+      });
+    }
+
+    // Generate HTML for history
+    this.previewPanel.webview.html = this.generateHistoryHtml(edits, currentIndex);
+  }
+
+  private generateHistoryHtml(edits: MapEdit[], currentIndex: number): string {
+    const items = edits
+      .map((edit, index) => {
+        const isCurrent = index === currentIndex;
+        const isPast = index <= currentIndex;
+        const className = isCurrent ? 'current' : isPast ? 'past' : 'future';
+
+        return `
+        <div class="history-item ${className}">
+          <div class="time">${new Date(edit.timestamp).toLocaleTimeString()}</div>
+          <div class="description">${edit.description}</div>
+          <div class="changes">${edit.changes.length} change(s)</div>
+        </div>
+      `;
+      })
+      .join('');
+
+    return `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <style>
+          body {
+            font-family: var(--vscode-font-family);
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editor-background);
+            padding: 20px;
+          }
+          .history-item {
+            padding: 10px;
+            margin: 5px 0;
+            border-radius: 5px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+          }
+          .history-item.current {
+            background-color: var(--vscode-editor-selectionBackground);
+            border: 2px solid var(--vscode-focusBorder);
+          }
+          .history-item.past {
+            opacity: 0.8;
+          }
+          .history-item.future {
+            opacity: 0.5;
+            font-style: italic;
+          }
+          .time {
+            font-size: 0.9em;
+            color: var(--vscode-descriptionForeground);
+          }
+          .description {
+            font-weight: bold;
+          }
+          .changes {
+            font-size: 0.9em;
+            color: var(--vscode-descriptionForeground);
+          }
+        </style>
+      </head>
+      <body>
+        <h2>Edit History</h2>
+        <div class="history-list">
+          ${items}
+        </div>
+      </body>
+      </html>
+    `;
+  }
+
+  public clearHistory(uri?: vscode.Uri): void {
+    if (uri) {
+      const history = this.editHistories.get(uri.toString());
+      if (history) {
+        history.clear();
+        this.updateStatusBar();
+      }
+    } else {
+      // Clear all histories
+      this.editHistories.clear();
+      this.updateStatusBar();
+    }
+  }
+}


### PR DESCRIPTION
- Created comprehensive undo/redo system with EditHistory class
- Implemented UndoRedoProvider managing edit history per file
- Added visual preview panel showing affected tiles before undo/redo
- Created enhanced quick action commands that integrate with undo system
- Added status bar indicator showing undo/redo availability
- Implemented keyboard shortcuts (Cmd+Alt+Z/Y on Mac, Ctrl+Alt+Z/Y on Windows)
- Added visual grid preview highlighting tiles to be changed
- Created history panel showing all edits with timestamps
- Supports fill area, replace all, and tile set replacements
- Added comprehensive tests for edit history functionality
