### PR TITLE
Fix tile validation to accept tiles 163-165 (Landslide/Dense/Unstable Rubble)

### DIFF
--- a/src/validation/mapValidator.test.ts
+++ b/src/validation/mapValidator.test.ts
@@ -252,5 +252,32 @@ tiles{
       expect(results.errors).toHaveLength(0);
       expect(results).toHaveProperty('info');
     });
+
+    it('should accept tiles 163, 164, and 165 as valid rubble tiles', async () => {
+      mockDocument = {
+        getText: () => `info{
+rowcount:3
+colcount:5
+}
+tiles{
+1,163,164,165,1,
+1,2,3,4,5,
+101,1,1,1,26,
+}`,
+        languageId: 'manicminers',
+      } as any;
+
+      const validator = new MapValidator(mockDocument);
+      const results = await validator.validate();
+
+      // Should not have errors about invalid tile IDs for 163, 164, 165
+      const invalidTileErrors = results.errors.filter(
+        e =>
+          e.message.includes('Invalid tile ID') &&
+          (e.message.includes('163') || e.message.includes('164') || e.message.includes('165'))
+      );
+
+      expect(invalidTileErrors).toHaveLength(0);
+    });
   });
 });

--- a/src/validation/mapValidator.ts
+++ b/src/validation/mapValidator.ts
@@ -159,7 +159,7 @@ export class MapValidator {
         const tileId = this.tiles[row][col];
 
         // Check for invalid tile IDs
-        if (isNaN(tileId) || tileId < 1 || tileId > 115) {
+        if (isNaN(tileId) || tileId < 1 || tileId > 165) {
           errors.push({
             type: 'error',
             message: `Invalid tile ID ${tileId} at [${row}, ${col}]`,


### PR DESCRIPTION
- Updated mapValidator to accept tile IDs up to 165 instead of 115
- Added test to ensure tiles 163, 164, and 165 are recognized as valid
- These tiles are used in official game levels like 14_Descent_to_the_Tunnels.dat
- Fixes false positive validation errors for legitimate rubble tiles
