### PR TITLE
Fix duplicate command registration error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -477,9 +477,6 @@ script{
         category: 'custom',
       });
     }),
-    vscode.commands.registerCommand('manicMiners.runValidation', () => {
-      vscode.commands.executeCommand('manicMiners.validateMap');
-    }),
     vscode.commands.registerCommand('manicMiners.showMapInfo', () => {
       // Show detailed map info in a quick pick or information message
       const editor = vscode.window.activeTextEditor;


### PR DESCRIPTION
## Summary
This PR fixes the extension activation error caused by duplicate command registration.

## Issue
When launching the extension, users see the error:
```
Activating extension 'Wal33D.manic-miners-dat' failed: command 'manicMiners.runValidation' already exists.
```

## Root Cause
The command `manicMiners.runValidation` was being registered twice:
1. In `validationCommands.ts` - the proper implementation that runs full validation
2. In `extension.ts` - a redundant registration that just called `manicMiners.validateMap`

## Fix
Removed the duplicate registration from `extension.ts`. The command is properly registered and implemented in `validationCommands.ts`.

## Testing
- ✅ Extension now activates without errors
- ✅ Validation command still works correctly
- ✅ All TypeScript and ESLint checks pass