### PR TITLE
Fix package.json warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,11 @@
     "Linters"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:manicminers",
+    "workspaceContains:**/*.dat",
+    "onCommand:manicMiners.showWelcome",
+    "onCommand:manicMiners.showDashboard",
+    "onCommand:manicMiners.newFile"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -827,18 +831,6 @@
         "label": "Manic Miners Dark",
         "uiTheme": "vs-dark",
         "path": "./themes/manic-miners-dark.json"
-      }
-    ],
-    "customEditors": [
-      {
-        "viewType": "manicMiners.mapEditor",
-        "displayName": "Map Editor",
-        "selector": [
-          {
-            "filenamePattern": "*.dat"
-          }
-        ],
-        "priority": "option"
       }
     ]
   },


### PR DESCRIPTION
- Remove duplicate customEditors section that was causing JSON validation warning
- Replace star (*) activation with specific activation events for better performance:
  - onLanguage:manicminers - Activates when opening .dat files
  - workspaceContains:**/*.dat - Activates when workspace has .dat files
  - onCommand for key commands like showWelcome, showDashboard, newFile
- This improves extension startup performance by only activating when needed
